### PR TITLE
CMake build support for MinGW compiler

### DIFF
--- a/SPICE/1.0.2/CMakeLists.txt
+++ b/SPICE/1.0.2/CMakeLists.txt
@@ -1,0 +1,48 @@
+project(SPICE CXX C)
+cmake_minimum_required(VERSION 3.0.0)
+set (CMAKE_VERBOSE_MAKEFILE on)
+
+if (NOT MINGW)
+    message( FATAL_ERROR "SPICE CMake build has been tested only with MINGW yet. CMake will exit." )
+endif ()
+
+# Append our module directory to CMake
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+# Windows DLLs are "runtime" for CMake. Output them to "bin"
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+#################################################################################
+# Setup C/C++ compiler options
+#################################################################################
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING
+        "Choose the type of build, options are: None Debug Release" FORCE)
+endif()
+message(STATUS "Setting SPICE build type - ${CMAKE_BUILD_TYPE}")
+
+if (CMAKE_BUILD_TYPE STREQUAL "")
+    set( CMAKE_BUILD_TYPE "RelWithDebInfo" )
+endif ()
+
+# For Debug build types, append a "d" to the library names.
+set(CMAKE_DEBUG_POSTFIX "d" CACHE STRING "Set debug library postfix" FORCE)
+
+# Uncomment from next two lines to force statitc or dynamic library, default is autodetection
+if(SPICE_STATIC)
+    set( LIB_MODE STATIC )
+    message(STATUS "Building static libraries")
+else(SPICE_STATIC)
+    set( LIB_MODE SHARED )
+    message(STATUS "Building dynamic libraries")
+endif(SPICE_STATIC)
+
+option(SPICE_STATIC
+  "Set to OFF|ON (default is OFF) to control build of POCO as STATIC library" OFF)
+
+add_subdirectory(SPICE_BIG)
+add_subdirectory(SPICE_Core)
+add_subdirectory(SPICE_ES_POCO)
+add_subdirectory(SPICE_XML_POCO)
+

--- a/SPICE/1.0.2/CMakeLists.txt
+++ b/SPICE/1.0.2/CMakeLists.txt
@@ -2,9 +2,11 @@ project(SPICE CXX C)
 cmake_minimum_required(VERSION 3.0.0)
 set (CMAKE_VERBOSE_MAKEFILE on)
 
+# The cmake file have been tested only with MinGW compiler yet
 if (NOT MINGW)
     message( FATAL_ERROR "SPICE CMake build has been tested only with MINGW yet. CMake will exit." )
 endif ()
+
 
 # Append our module directory to CMake
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
@@ -13,9 +15,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 # Windows DLLs are "runtime" for CMake. Output them to "bin"
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-#################################################################################
 # Setup C/C++ compiler options
-#################################################################################
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING
         "Choose the type of build, options are: None Debug Release" FORCE)
@@ -29,7 +29,6 @@ endif ()
 # For Debug build types, append a "d" to the library names.
 set(CMAKE_DEBUG_POSTFIX "d" CACHE STRING "Set debug library postfix" FORCE)
 
-# Uncomment from next two lines to force statitc or dynamic library, default is autodetection
 if(SPICE_STATIC)
     set( LIB_MODE STATIC )
     message(STATUS "Building static libraries")

--- a/SPICE/1.0.2/SPICE_BIG/CMakeLists.txt
+++ b/SPICE/1.0.2/SPICE_BIG/CMakeLists.txt
@@ -1,0 +1,11 @@
+set(LIBNAME "SPICE_BIG")
+
+# Sources
+file(GLOB_RECURSE SRCS "*.cpp")
+
+add_library( "${LIBNAME}" ${LIB_MODE} ${SRCS} )
+set_target_properties( "${LIBNAME}"
+    PROPERTIES
+    OUTPUT_NAME ${LIBNAME}
+    COMPILE_FLAGS "-std=c++11"
+    )

--- a/SPICE/1.0.2/SPICE_Core/CMakeLists.txt
+++ b/SPICE/1.0.2/SPICE_Core/CMakeLists.txt
@@ -1,0 +1,15 @@
+set(LIBNAME "SPICE_Core")
+
+# Sources - recurse to also add internal subdirectory
+file(GLOB_RECURSE SRCS "*.cpp")
+
+add_library( "${LIBNAME}" ${LIB_MODE} ${SRCS} )
+set_target_properties( "${LIBNAME}"
+    PROPERTIES
+    OUTPUT_NAME ${LIBNAME}
+    COMPILE_FLAGS "-std=c++11"
+    )
+    
+target_include_directories( "${LIBNAME}" PUBLIC ${CMAKE_SOURCE_DIR}/SPICE_BIG)
+
+target_link_libraries( "${LIBNAME}" SPICE_BIG)

--- a/SPICE/1.0.2/SPICE_Core/CMakeLists.txt
+++ b/SPICE/1.0.2/SPICE_Core/CMakeLists.txt
@@ -11,5 +11,4 @@ set_target_properties( "${LIBNAME}"
     )
     
 target_include_directories( "${LIBNAME}" PUBLIC ${CMAKE_SOURCE_DIR}/SPICE_BIG)
-
 target_link_libraries( "${LIBNAME}" SPICE_BIG)

--- a/SPICE/1.0.2/SPICE_ES_POCO/CMakeLists.txt
+++ b/SPICE/1.0.2/SPICE_ES_POCO/CMakeLists.txt
@@ -1,0 +1,19 @@
+set(LIBNAME "SPICE_ES_POCO")
+
+# Sources 
+find_package(Poco REQUIRED Net) 
+
+file(GLOB_RECURSE SRCS "*.cpp")
+
+add_library( "${LIBNAME}" ${LIB_MODE} ${SRCS} )
+set_target_properties( "${LIBNAME}"
+    PROPERTIES
+    OUTPUT_NAME ${LIBNAME}
+    COMPILE_FLAGS "-std=c++11"
+    )
+    
+target_include_directories( "${LIBNAME}" PUBLIC ${CMAKE_SOURCE_DIR}/SPICE_BIG "${Poco_INCLUDE_DIRS}")
+
+target_link_libraries( "${LIBNAME}" SPICE_BIG 
+    debug ${Poco_Net_LIBRARY_DEBUG} ${Poco_Foundation_LIBRARY_DEBUG}
+    optimized ${Poco_Net_LIBRARY} ${Poco_Foundation_LIBRARY})

--- a/SPICE/1.0.2/SPICE_ES_POCO/EventConnection.cpp
+++ b/SPICE/1.0.2/SPICE_ES_POCO/EventConnection.cpp
@@ -10,6 +10,7 @@
 #include "EventConnection.h"
 
 #include <sstream>
+#include <system_error>
 
 #include "Poco/URI.h"
 #include "Poco/Timespan.h"

--- a/SPICE/1.0.2/SPICE_XML_POCO/CMakeLists.txt
+++ b/SPICE/1.0.2/SPICE_XML_POCO/CMakeLists.txt
@@ -1,0 +1,19 @@
+set(LIBNAME "SPICE_XML_POCO")
+
+# Sources 
+find_package(Poco REQUIRED XML) 
+
+file(GLOB_RECURSE SRCS "*.cpp")
+
+add_library( "${LIBNAME}" ${LIB_MODE} ${SRCS} )
+set_target_properties( "${LIBNAME}"
+    PROPERTIES
+    OUTPUT_NAME ${LIBNAME}
+    COMPILE_FLAGS "-std=c++11"
+    )
+    
+target_include_directories( "${LIBNAME}" PUBLIC ${CMAKE_SOURCE_DIR}/SPICE_BIG "${Poco_INCLUDE_DIRS}")
+
+target_link_libraries( "${LIBNAME}" SPICE_BIG 
+    debug ${Poco_XML_LIBRARY_DEBUG} ${Poco_Foundation_LIBRARY_DEBUG}
+    optimized ${Poco_XML_LIBRARY} ${Poco_Foundation_LIBRARY})

--- a/SPICE/1.0.2/cmake/FindPoco.cmake
+++ b/SPICE/1.0.2/cmake/FindPoco.cmake
@@ -1,0 +1,210 @@
+# - finds the Poco C++ libraries
+# This module finds the Applied Informatics Poco libraries.
+# It supports the following components:
+#
+# Util (loaded by default)
+# Foundation (loaded by default)
+# XML
+# Zip
+# Crypto
+# Data
+# Net
+# NetSSL_OpenSSL
+# OSP
+#
+# Usage:
+#	set(ENV{Poco_DIR} path/to/poco/sdk)
+#	find_package(Poco REQUIRED OSP Data Crypto) 
+#
+# On completion, the script defines the following variables:
+#	
+#	- Compound variables:
+#   Poco_FOUND 
+#		- true if all requested components were found.
+#	Poco_LIBRARIES 
+#		- contains release (and debug if available) libraries for all requested components.
+#		  It has the form "optimized LIB1 debug LIBd1 optimized LIB2 ...", ready for use with the target_link_libraries command.
+#	Poco_INCLUDE_DIRS
+#		- Contains include directories for all requested components.
+#
+#	- Component variables:
+#   Poco_Xxx_FOUND 
+#		- Where Xxx is the properly cased component name (eg. 'Util', 'OSP'). 
+#		  True if a component's library or debug library was found successfully.
+#	Poco_Xxx_LIBRARY 
+#		- Library for component Xxx.
+#	Poco_Xxx_LIBRARY_DEBUG 
+#		- debug library for component Xxx
+#   Poco_Xxx_INCLUDE_DIR
+#		- include directory for component Xxx
+#
+#  	- OSP BundleCreator variables: (i.e. bundle.exe on windows, bundle on unix-likes)
+#		(is only discovered if OSP is a requested component)
+#	Poco_OSP_Bundle_EXECUTABLE_FOUND 
+#		- true if the bundle-creator executable was found.
+#	Poco_OSP_Bundle_EXECUTABLE
+#		- the path to the bundle-creator executable.
+#
+# Author: Andreas Stahl andreas.stahl@tu-dresden.de
+
+set(Poco_HINTS
+	/usr/local
+	C:/AppliedInformatics
+	${Poco_DIR} 
+	$ENV{Poco_DIR}
+)
+
+if(NOT Poco_ROOT_DIR)
+	# look for the root directory, first for the source-tree variant
+	find_path(Poco_ROOT_DIR 
+		NAMES Foundation/include/Poco/Poco.h
+		HINTS ${Poco_HINTS}
+	)
+	if(NOT Poco_ROOT_DIR)
+		# this means poco may have a different directory structure, maybe it was installed, let's check for that
+		message(STATUS "Looking for Poco install directory structure.")
+		find_path(Poco_ROOT_DIR 
+			NAMES include/Poco/Poco.h
+			HINTS ${Poco_HINTS}
+		)
+		if(NOT Poco_ROOT_DIR) 
+			# poco was still not found -> Fail
+			if(Poco_FIND_REQUIRED)
+				message(FATAL_ERROR "Poco: Could not find Poco install directory")
+			endif()
+			if(NOT Poco_FIND_QUIETLY)
+				message(STATUS "Poco: Could not find Poco install directory")
+			endif()
+			return()
+		else()
+			# poco was found with the make install directory structure
+			message(STATUS "Assuming Poco install directory structure at ${Poco_ROOT_DIR}.")
+			set(Poco_INSTALLED true)
+		endif()
+	endif()
+endif()
+
+# add dynamic library directory
+if(WIN32)
+	find_path(Poco_RUNTIME_LIBRARY_DIRS
+		NAMES PocoFoundation.dll
+		HINTS ${Poco_ROOT_DIR}
+		PATH_SUFFIXES 
+			bin
+			lib
+	)
+endif()
+
+# if installed directory structure, set full include dir
+if(Poco_INSTALLED)
+	set(Poco_INCLUDE_DIRS ${Poco_ROOT_DIR}/include/ CACHE PATH "The global include path for Poco")
+endif()
+
+# append the default minimum components to the list to find
+list(APPEND components 
+	${Poco_FIND_COMPONENTS} 
+	# default components:
+	"Util" 
+	"Foundation"
+)
+list(REMOVE_DUPLICATES components) # remove duplicate defaults
+
+foreach( component ${components} )
+	#if(NOT Poco_${component}_FOUND)
+		
+	# include directory for the component
+	if(NOT Poco_${component}_INCLUDE_DIR)
+		find_path(Poco_${component}_INCLUDE_DIR
+			NAMES 
+				Poco/${component}.h 	# e.g. Foundation.h
+				Poco/${component}/${component}.h # e.g. OSP/OSP.h Util/Util.h
+			HINTS
+				${Poco_ROOT_DIR}
+			PATH_SUFFIXES
+				include
+				${component}/include
+		)
+	endif()
+	if(NOT Poco_${component}_INCLUDE_DIR)
+		message(FATAL_ERROR "Poco_${component}_INCLUDE_DIR NOT FOUND")
+	else()
+		list(APPEND Poco_INCLUDE_DIRS ${Poco_${component}_INCLUDE_DIR})
+	endif()
+
+	# release library
+	if(NOT Poco_${component}_LIBRARY)
+		find_library(
+			Poco_${component}_LIBRARY 
+			NAMES Poco${component} 
+			HINTS ${Poco_ROOT_DIR}
+			PATH_SUFFIXES
+				lib
+				bin
+		)
+		if(Poco_${component}_LIBRARY)
+			message(STATUS "Found Poco ${component}: ${Poco_${component}_LIBRARY}")
+		endif()
+	endif()
+	if(Poco_${component}_LIBRARY)
+		list(APPEND Poco_LIBRARIES "optimized" ${Poco_${component}_LIBRARY} )
+		mark_as_advanced(Poco_${component}_LIBRARY)
+	endif()
+
+	# debug library
+	if(NOT Poco_${component}_LIBRARY_DEBUG)
+		find_library(
+			Poco_${component}_LIBRARY_DEBUG
+			Names Poco${component}d
+			HINTS ${Poco_ROOT_DIR}
+			PATH_SUFFIXES
+				lib
+				bin
+		)
+		if(Poco_${component}_LIBRARY_DEBUG)
+			message(STATUS "Found Poco ${component} (debug): ${Poco_${component}_LIBRARY_DEBUG}")
+		endif()
+	endif(NOT Poco_${component}_LIBRARY_DEBUG)
+	if(Poco_${component}_LIBRARY_DEBUG)
+		list(APPEND Poco_LIBRARIES "debug" ${Poco_${component}_LIBRARY_DEBUG})
+		mark_as_advanced(Poco_${component}_LIBRARY_DEBUG)
+	endif()
+
+	# mark component as found or handle not finding it
+	if(Poco_${component}_LIBRARY_DEBUG OR Poco_${component}_LIBRARY)
+		set(Poco_${component}_FOUND TRUE)
+	elseif(NOT Poco_FIND_QUIETLY)
+		message(FATAL_ERROR "Could not find Poco component ${component}!")
+	endif()
+endforeach()
+
+if(DEFINED Poco_LIBRARIES)
+	set(Poco_FOUND true)
+endif()
+
+if(${Poco_OSP_FOUND})
+	# find the osp bundle program
+	find_program(
+		Poco_OSP_Bundle_EXECUTABLE 
+		NAMES bundle
+		HINTS 
+			${Poco_RUNTIME_LIBRARY_DIRS}
+			${Poco_ROOT_DIR}
+		PATH_SUFFIXES
+			bin
+			OSP/BundleCreator/bin/Darwin/x86_64
+			OSP/BundleCreator/bin/Darwin/i386
+		DOC "The executable that bundles OSP packages according to a .bndlspec specification."
+	)
+	if(Poco_OSP_Bundle_EXECUTABLE)
+		set(Poco_OSP_Bundle_EXECUTABLE_FOUND true)
+	endif()
+	# include bundle script file
+	find_file(Poco_OSP_Bundles_file NAMES PocoBundles.cmake HINTS ${CMAKE_MODULE_PATH})
+	if(${Poco_OSP_Bundles_file})
+		include(${Poco_OSP_Bundles_file})
+	endif()
+endif()
+
+message(STATUS "Found Poco: ${Poco_LIBRARIES}")
+
+

--- a/SPICE/1.0.2/cmake/FindPoco.cmake
+++ b/SPICE/1.0.2/cmake/FindPoco.cmake
@@ -1,3 +1,7 @@
+# This file has been copied from
+# https://github.com/astahl/poco-cmake/blob/master/cmake/FindPoco.cmake
+# Thank you to Andreas Stahl for creating this file
+#
 # - finds the Poco C++ libraries
 # This module finds the Applied Informatics Poco libraries.
 # It supports the following components:


### PR DESCRIPTION
Hi,

first I would like to say thank you for sharing your SiLA provider library. We were about to implement our own library, as I found this one here. Really great!!!

We use the MinGW compiler in our company. Therefore I created CMake files to support building the SPICE library with CMake. The CMake support has been tested only with MinGW yet and the CMake files may need to be adjusted to work with Linux GCC or Visual Studio.

I also added one include to **EventConnection.cpp** because `std::sysstem_error` was not declared - at least for MinGW compiler.
