### PR TITLE
Fixed Cmake build for Linux

### DIFF
--- a/SPICE/CMakeLists.txt
+++ b/SPICE/CMakeLists.txt
@@ -2,11 +2,6 @@ project(SPICE CXX C)
 cmake_minimum_required(VERSION 3.0.0)
 set (CMAKE_VERBOSE_MAKEFILE on)
 
-# The cmake file have been tested only with MinGW compiler yet
-if (NOT MINGW)
-    message( FATAL_ERROR "SPICE CMake build has been tested only with MINGW yet. CMake will exit." )
-endif ()
-
 
 # Append our module directory to CMake
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
@@ -26,8 +21,11 @@ if (CMAKE_BUILD_TYPE STREQUAL "")
     set( CMAKE_BUILD_TYPE "RelWithDebInfo" )
 endif ()
 
-# For Debug build types, append a "d" to the library names.
+
+# For Debug build types, append a "d" to the library names for Windows
+if (NOT MINGW)
 set(CMAKE_DEBUG_POSTFIX "d" CACHE STRING "Set debug library postfix" FORCE)
+endif ()
 
 if(SPICE_STATIC)
     set( LIB_MODE STATIC )

--- a/SPICE/SPICE_BIG/CMakeLists.txt
+++ b/SPICE/SPICE_BIG/CMakeLists.txt
@@ -9,3 +9,7 @@ set_target_properties( "${LIBNAME}"
     OUTPUT_NAME ${LIBNAME}
     COMPILE_FLAGS "-std=c++11"
     )
+
+install(TARGETS "${LIBNAME}" DESTINATION lib)
+install(DIRECTORY ./ DESTINATION include/SPICE FILES_MATCHING PATTERN "*.h")
+

--- a/SPICE/SPICE_BIG/GeneralFunctions.cpp
+++ b/SPICE/SPICE_BIG/GeneralFunctions.cpp
@@ -11,7 +11,7 @@
 
 #include <sstream>
 
-#ifdef LINUX
+#ifdef __linux__
 #include <stdlib.h>
 #endif
 
@@ -24,7 +24,7 @@ namespace SPICE
 		void GeneralFunctions::getLocaltimeInfo(const time_t& time, struct tm& timeinfo)
 		{
 			std::lock_guard<std::mutex> lockGuard(_timeConverterMutex);
-#ifdef LINUX
+#ifdef __linux__
 			struct tm* localTime = localtime(&time); // TODO: check if time is correct
 			timeinfo = *localTime;
 	//		delete localTime;
@@ -35,7 +35,7 @@ namespace SPICE
 		void GeneralFunctions::getUTCtimeInfo(const time_t& time, struct tm& timeinfo)
 		{
 			std::lock_guard<std::mutex> lockGuard(_timeConverterMutex);
-#ifdef LINUX
+#ifdef __linux__
 			struct tm* utcTime = gmtime(&time); // TODO: check if time is correct
 			timeinfo = *utcTime;
 	//		delete utcTime;
@@ -56,7 +56,7 @@ namespace SPICE
 
 		void GeneralFunctions::wroteFileToDisk()
 		{
-#ifdef LINUX
+#ifdef __linux__
 			std::string command = "sync";
 			std::system(&command[0]);
 #endif // LINUX

--- a/SPICE/SPICE_Core/CMakeLists.txt
+++ b/SPICE/SPICE_Core/CMakeLists.txt
@@ -12,3 +12,6 @@ set_target_properties( "${LIBNAME}"
     
 target_include_directories( "${LIBNAME}" PUBLIC ${CMAKE_SOURCE_DIR}/SPICE_BIG)
 target_link_libraries( "${LIBNAME}" SPICE_BIG)
+
+install(TARGETS "${LIBNAME}" DESTINATION lib)
+install(DIRECTORY ./ DESTINATION include/SPICE FILES_MATCHING PATTERN "*.h")

--- a/SPICE/SPICE_ES_POCO/CMakeLists.txt
+++ b/SPICE/SPICE_ES_POCO/CMakeLists.txt
@@ -14,6 +14,14 @@ set_target_properties( "${LIBNAME}"
     
 target_include_directories( "${LIBNAME}" PUBLIC ${CMAKE_SOURCE_DIR}/SPICE_BIG "${Poco_INCLUDE_DIRS}")
 
+if (MINGW)
 target_link_libraries( "${LIBNAME}" SPICE_BIG 
     debug ${Poco_Net_LIBRARY_DEBUG} ${Poco_Foundation_LIBRARY_DEBUG}
     optimized ${Poco_Net_LIBRARY} ${Poco_Foundation_LIBRARY})
+else ()
+target_link_libraries( "${LIBNAME}" SPICE_BIG ${Poco_Net_LIBRARY} ${Poco_Foundation_LIBRARY})
+endif ()
+
+install(TARGETS "${LIBNAME}" DESTINATION lib)
+install(DIRECTORY ./ DESTINATION include/SPICE FILES_MATCHING PATTERN "*.h")
+

--- a/SPICE/SPICE_XML_POCO/CMakeLists.txt
+++ b/SPICE/SPICE_XML_POCO/CMakeLists.txt
@@ -14,6 +14,15 @@ set_target_properties( "${LIBNAME}"
     
 target_include_directories( "${LIBNAME}" PUBLIC ${CMAKE_SOURCE_DIR}/SPICE_BIG "${Poco_INCLUDE_DIRS}")
 
+if (MINGW)
 target_link_libraries( "${LIBNAME}" SPICE_BIG 
     debug ${Poco_XML_LIBRARY_DEBUG} ${Poco_Foundation_LIBRARY_DEBUG}
     optimized ${Poco_XML_LIBRARY} ${Poco_Foundation_LIBRARY})
+else ()
+target_link_libraries( "${LIBNAME}" SPICE_BIG ${Poco_XML_LIBRARY} ${Poco_Foundation_LIBRARY})
+endif ()
+
+
+install(TARGETS "${LIBNAME}" DESTINATION lib)
+install(DIRECTORY ./ DESTINATION include/SPICE FILES_MATCHING PATTERN "*.h")
+

--- a/SPI_Template/SPI_Template/SPITemplate.cpp
+++ b/SPI_Template/SPI_Template/SPITemplate.cpp
@@ -1,7 +1,7 @@
 // SPITemplate.cpp : Definiert den Einstiegspunkt für die Konsolenanwendung.
 //
 
-#ifdef LINUX
+#ifdef __linux__
 #include <unistd.h>
 #else
 #include "stdafx.h"
@@ -14,7 +14,7 @@
 #include "EthernetServer.h"
 #include "ResourceProvider.h"
 
-#ifdef LINUX
+#ifdef __linux__
 int main()
 {
     if(true)


### PR DESCRIPTION
Hi Lukas,

I tried to compile the SPICE library with CMake on a Linux system and the build process failed because of some issues:
1. You use the define LINUX to test if you compile for a LINUX system, but for a standard build on linux, this is not defined. I changed this to `__linux__` because this is defined for all linux builds (see https://sourceforge.net/p/predef/wiki/OperatingSystems/)
2. I modified the CMake files to properly install the the libraries and include files to a standard place (e.g. /usr/local/bin and /usr/local/include/SPICE)

After these modification I could successfully build and install the libraries with CMake on Linux. I tested the created libraries with the SPI_DeviceSimulator and could connect successfully with the SOFIA PMS.
